### PR TITLE
Make Iterables Closeable to Properly Close Accumulo Scanners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: java
 script: mvn test -Ptest
 branches:

--- a/core/src/main/java/com/v5analytics/simpleorm/CloseableIterable.java
+++ b/core/src/main/java/com/v5analytics/simpleorm/CloseableIterable.java
@@ -1,0 +1,8 @@
+package com.v5analytics.simpleorm;
+
+import java.io.Closeable;
+
+public interface CloseableIterable<T> extends Iterable<T>, Closeable, AutoCloseable {
+    @Override
+    CloseableIterator<T> iterator();
+}

--- a/core/src/main/java/com/v5analytics/simpleorm/CloseableIterator.java
+++ b/core/src/main/java/com/v5analytics/simpleorm/CloseableIterator.java
@@ -1,0 +1,7 @@
+package com.v5analytics.simpleorm;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+public interface CloseableIterator<T> extends Iterator<T>, Closeable, AutoCloseable {
+}


### PR DESCRIPTION
The `findAll` and `findByIdStartsWith` methods in `AccumuloSimpleOrmSession` were opening Accumulo scanners that could not properly be closed. This PR adds a close method to the returned Iterable and Iterator so that the client can clean up when finished.